### PR TITLE
Refactor clean name

### DIFF
--- a/em/__init__.py
+++ b/em/__init__.py
@@ -30,6 +30,7 @@ import fnmatch
 import itertools
 import json
 import os
+import re
 import sys
 from collections import defaultdict
 
@@ -84,21 +85,17 @@ def do_find(lookup, term):
     return [(r, translate(lookup, r)) for r in results]
 
 
+def clean_name(name):
+    """Clean emoji name replacing specials chars by underscore"""
+    special_chars = '[-. ]'  # square brackets are part of the regex
+    return re.sub(special_chars, '_', name)
+
+
 def cli():
     # CLI argument parsing.
     arguments = docopt(__doc__)
-    names = arguments['<name>']
+    names = tuple(map(clean_name, arguments['<name>']))
     no_copy = arguments['--no-copy']
-
-    # Cleanup input names, to humanize things.
-    for i, name in enumerate(names):
-        # Replace -/ /. with _.
-        name = name.replace('-', '_')
-        name = name.replace(' ', '_')
-        name = name.replace('.', '_')
-
-        # Over-write original name.
-        names[i] = name
 
     # Marker for if the given emoji isn't found.
     missing = False


### PR DESCRIPTION
This is one of those very personal and subjectives PR… so just throw it in the garbage bin if it sounds like bullshit. The thing is that I felt this snippet could be more _pythonic_ (whatever this means):

``` python
    # Cleanup input names, to humanize things.
    for i, name in enumerate(names):
        # Replace -/ /. with _.
        name = name.replace('-', '_')
        name = name.replace(' ', '_')
        name = name.replace('.', '_')

        # Over-write original name.
        names[i] = name
```

Instead of redefining `name` three times, and then redefine `names[i]` I suggest to use a simpler approach: create a method to clean up names and apply it with `map` once `names` are loaded. That's what this PR is about.

I do believe current code ir more _explicit_, but I do believe the PR makes it more _beautiful_ — so you gotta choose which verse from the Zen of Python you like better ; )
