### PR TITLE
Allow for a user ~/.emoji.json file

### DIFF
--- a/em/__init__.py
+++ b/em/__init__.py
@@ -37,6 +37,7 @@ import xerox
 from docopt import docopt
 
 EMOJI_PATH = os.path.join(os.path.dirname(__file__), 'emojis.json')
+CUSTOM_EMOJI_PATH = os.path.join(os.path.expanduser('~/.emojis.json'))
 
 
 def parse_emojis(filename=EMOJI_PATH):
@@ -110,6 +111,9 @@ def cli():
 
     # Grab the lookup dictionary.
     lookup = parse_emojis()
+
+    if os.path.isfile(CUSTOM_EMOJI_PATH):
+        lookup.update(parse_emojis(CUSTOM_EMOJI_PATH))
 
     # Search mode.
     if arguments['-s']:


### PR DESCRIPTION
I didn't see an obvious place that would let me update the existing `emojis.json` file, so I went ahead and added the ability myself.

Pretty simple - this will look for `~/.emojis.json` and if it's found it will update the existing emoji dictionary with the contents there. If it's not found it just does what it normally did.

I used `os.path.isfile` for no particular reason other than it's shorter apparent lines. It could've been a `try/except`, but I don't know if there's a particular reason to take that approach aside from EAFP vs. LBYL.

I'm totally happy to change this up if there's a better way to do it, but this scratches _my_ itch, so maybe it will be good for other people, too :)
