### PR TITLE
Drop support for EOL Python, add new versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import re
 import sys
 from codecs import open
 
@@ -37,18 +36,20 @@ setup(
     install_requires=requires,
     license='ISC',
     zip_safe=False,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=(
         # 'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     )
 )


### PR DESCRIPTION
Python 2.6, 3.3 and 3.4 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history
